### PR TITLE
Preserve line breaks from command output

### DIFF
--- a/src/style/_terminal.scss
+++ b/src/style/_terminal.scss
@@ -20,6 +20,10 @@
 	.terminal__sign {
 		color: var(--color-text-disabled);
 	}
+
+	.terminal__text {
+		white-space: pre-line;
+	}
 }
 
 .terminal__input-wrapper {


### PR DESCRIPTION
e.g.: `statusall` outputs multiple line breaks characters (`\n`) that are ignored when displayed in the page.