### PR TITLE
[WIP] Add farming info for statistics

### DIFF
--- a/src/components/AppNavigation.vue
+++ b/src/components/AppNavigation.vue
@@ -18,6 +18,7 @@
 			<div class="navigation-category navigation-category--pull-bottom">
 				<navigation-category-title :name="$t('statistics')"></navigation-category-title>
 				<navigation-bots></navigation-bots>
+				<navigation-farming-info></navigation-farming-info>
 				<navigation-statistics></navigation-statistics>
 			</div>
 		</template>
@@ -36,12 +37,13 @@
 	import NavigationCategoryTitle from './NavigationCategoryTitle.vue';
 	import NavigationBots from './NavigationBots.vue';
 	import NavigationStatistics from './NavigationStatistics.vue';
+	import NavigationFarmingInfo from './NavigationFarmingInfo.vue';
 
 	import { mapGetters } from 'vuex';
 
 	export default {
 		name: 'app-navigation',
-		components: { NavigationLink, NavigationCategoryTitle, NavigationStatistics, NavigationBots },
+		components: { NavigationLink, NavigationCategoryTitle, NavigationStatistics, NavigationBots, NavigationFarmingInfo },
 		computed: mapGetters({
 			validPassword: 'auth/validPassword'
 		})

--- a/src/components/NavigationFarmingInfo.vue
+++ b/src/components/NavigationFarmingInfo.vue
@@ -1,0 +1,61 @@
+<template>
+	<div v-if="cardsRemaining < 0" class="statistic-farming">
+		<div class="farming-card">
+			<span class="farming-card__value">{{ cardsRemaining }}</span>
+			<span class="farming-card__name">{{ $t(`farming-info-cards`) }}</span>
+		</div>
+	</div>
+</template>
+
+<script>
+	import { mapGetters } from 'vuex';
+
+	export default {
+		name: 'navigation-farming-info',
+		computed: {
+			...mapGetters({
+				cardsRemaining: 'bots/cardsRemaining'
+			})
+		}
+	};
+</script>
+
+<style lang="scss">
+	.statistic-farming {
+		justify-content: center;
+		padding: 0 0.5em;
+
+		.app--small-navigation & {
+			grid-template-columns: 1fr;
+
+			.farming-card__name {
+				display: none;
+			}
+		}
+	}
+
+	.farming-card {
+		padding: 0.25em 0.1em;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		border-radius: 2px;
+		color: var(--color-text);
+		text-shadow: 0 0 1px var(--color-text-dark);
+		background: var(--color-theme);
+
+		.app--dark-mode & {
+			background: var(--color-theme-dark);
+		}
+	}
+
+	.farming-card__value {
+		font-weight: 600;
+		font-size: 1.2em;
+	}
+
+	.farming-card__name {
+		font-size: 0.9em;
+		text-transform: capitalize;
+	}
+</style>

--- a/src/components/NavigationFarmingInfo.vue
+++ b/src/components/NavigationFarmingInfo.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-if="cardsRemaining < 0" class="statistic-farming">
+	<div v-if="cardsRemaining != 0" class="statistic-farming">
 		<div class="farming-card">
 			<span class="farming-card__value">{{ cardsRemaining }}</span>
 			<span class="farming-card__name">{{ $t(`farming-info-cards`) }}</span>

--- a/src/components/NavigationFarmingInfo.vue
+++ b/src/components/NavigationFarmingInfo.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-if="cardsRemaining != 0" class="statistic-farming">
+	<div v-if="cardsRemaining !== 0" class="statistic-farming">
 		<div class="farming-card">
 			<span class="farming-card__value">{{ cardsRemaining }}</span>
 			<span class="farming-card__name">{{ $t(`farming-info-cards`) }}</span>


### PR DESCRIPTION
- [x] Add basic layout
- [x] Only show if we are currently farming
- [ ] Only show on FHD+ screens (hide on smaller)
- [ ] Restrict `cardsRemaining` to max. 999 (only when navigation is minimized)

Feel free to to commit to the branch.

Closes #79 