### PR TITLE
Add build:ci action

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - |
     set -eu
 
-    npm run-script build
+    npm run-script build:ci
 
     set +u # This is needed to continue Travis build
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ build_script:
     }
 
 
-    npm run-script build
+    npm run-script build:ci
 
 
     if ($LastExitCode -ne 0) {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"build": "webpack --config webpack.config.js --env production --progress",
 		"deploy": "webpack --config webpack.config.js --env production --deploy",
 		"build:analyze": "webpack --config webpack.config.js --env production --analyze",
+		"build:ci": "webpack --config webpack.config.js --env production",
 		"start": "webpack-dev-server --open --env development",
 		"generate-flags-helper": "node scripts/generate-flags-helper"
 	},

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Friendly web interface consuming ASF's IPC interface",
 	"scripts": {
 		"dev": "webpack --config webpack.config.js --env development --progress",
-		"build": "webpack --config webpack.config.js --env production --progress",
+		"build": "webpack --config webpack.config.js --env production",
 		"deploy": "webpack --config webpack.config.js --env production --deploy",
 		"build:analyze": "webpack --config webpack.config.js --env production --analyze",
 		"start": "webpack-dev-server --open --env development",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Friendly web interface consuming ASF's IPC interface",
 	"scripts": {
 		"dev": "webpack --config webpack.config.js --env development --progress",
-		"build": "webpack --config webpack.config.js --env production",
+		"build": "webpack --config webpack.config.js --env production --progress",
 		"deploy": "webpack --config webpack.config.js --env production --deploy",
 		"build:analyze": "webpack --config webpack.config.js --env production --analyze",
 		"start": "webpack-dev-server --open --env development",


### PR DESCRIPTION
ASF-ui CIs (AppVeyor and Travis) do not get along with `--progress`, and I want them to use `build` and not `deploy` as `deploy` should be reserved for main ASF and situations where you intend to include super-minified no-debug build.

Therefore I think that normal production build does not need `--progress`, as any eventual speed of compilation and feedback is already available in `dev` build.

Alternatively, we might want to add yet another action such as `ci` but I find it unnecessarily excessive. I'm pretty sure that you can add `--progress` yourself if you need it, no need to specify it as default value.

cc @Aareksio 