### PR TITLE
Add 'title' attribute to better distinguish games

### DIFF
--- a/src/views/modals/Bot.vue
+++ b/src/views/modals/Bot.vue
@@ -32,7 +32,7 @@
 			</div>
 
 			<div class="bot-games" v-if="bot.games.length && botsFarmingCount !== 0">
-				<div class="bot-game" :class="[game.farming ? 'status--farming' : 'status--disabled']" v-for="game in bot.games">
+				<div class="bot-game" :title="game.GameName" :class="[game.farming ? 'status--farming' : 'status--disabled']" v-for="game in bot.games">
 					<a target="_blank" :href="`https://store.steampowered.com/app/${game.AppID}/`">
 						<div class="bot-game__info">
 							<span class="bot-game__name">{{ game.GameName }}</span>


### PR DESCRIPTION
Games can have similar names, so when their title gets truncated we can't be sure which is which. Example:

![image](https://user-images.githubusercontent.com/35700659/51298911-b11ee600-1a0d-11e9-957a-7f0aeeb7d859.png)