### PR TITLE
Fix navigation URL change

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -25,7 +25,7 @@ router.beforeEach(async (routeTo, routeFrom, next) => {
 });
 
 router.afterEach((to, from) => {
-	storage.set('last-visited-page', to);
+	storage.set('last-visited-page', { name: to.name, query: to.query, params: to.params });
 });
 
 router.onError(err => {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -2,7 +2,7 @@ import store from '../store';
 import * as storage from '../utils/storage';
 
 let defaultView = store.getters['settings/defaultView'];
-if (defaultView === '_last-visited-page') defaultView = storage.get('last-visited-page', 'home');
+if (defaultView === '_last-visited-page') defaultView = storage.get('last-visited-page', { name: 'home' });
 
 export default [
 	{


### PR DESCRIPTION
Regression was caused by `JSON.stringify` throwing on circular dependency in `route` parameter. Fixed by extracting only the values needed.

I'm trying to figure out what caused the error to be suppressed inside `vue-router`.