### PR TITLE
Readd "|" symbol for log text

### DIFF
--- a/src/components/AsfLog.vue
+++ b/src/components/AsfLog.vue
@@ -49,7 +49,7 @@
 					process,
 					level,
 					logger,
-					text: text.join()
+					text: text.join('|')
 				};
 			},
 			onClose(event) {


### PR DESCRIPTION
Before            |  After
:-------------------------:|:-------------------------:
![27 24](https://user-images.githubusercontent.com/31552675/52228560-f6b72c00-28b2-11e9-8217-124d90a78525.png) |  ![9 26 42](https://user-images.githubusercontent.com/31552675/52228590-02a2ee00-28b3-11e9-922f-6ce55d409a08.png)
