### PR TITLE
[WIP] Improve statistics view for boxed layout

### DIFF
--- a/src/components/AppNavigation.vue
+++ b/src/components/AppNavigation.vue
@@ -94,5 +94,9 @@
 
 	.navigation-category--pull-bottom {
 		margin-top: auto;
+
+		.app--boxed-layout & {
+			margin-top: 1em;
+		}
 	}
 </style>


### PR DESCRIPTION
ToDo: Dont pull navigation category to bottom if content < window.width on boxed layout

Before            |  After
:-:|:-:
![03 04 46](https://user-images.githubusercontent.com/31552675/52455048-a22fdd00-2b4e-11e9-90f7-449923bdae9f.png) | ![03 03 48](https://user-images.githubusercontent.com/31552675/52455055-a9ef8180-2b4e-11e9-9bf8-a87682dd3ced.png)


