### PR TITLE
Add missing "farming" bot config category i18n entry

### DIFF
--- a/src/i18n/locale/default.json
+++ b/src/i18n/locale/default.json
@@ -60,6 +60,7 @@
 	"error": "Error",
 	"exit": "Exit",
 	"exit-message": "Exiting, good bye!",
+	"farming": "Farming",
 	"farming-info": "Farming Info",
 	"farming-info-cards": "cards remaining",
 	"farming-info-games": "games remaining",


### PR DESCRIPTION
https://github.com/JustArchiNET/ASF-ui/blob/20723dbcec0a7faa6d7e9c899520fe791b1caa2d/src/views/modals/BotConfiguration.vue#L50

^ this entry is still using here