### PR TITLE
Fix 'Invalid Date' in log for safari on iOS

### DIFF
--- a/src/components/AsfLog.vue
+++ b/src/components/AsfLog.vue
@@ -57,7 +57,8 @@
 				const [time, process, level, logger, ...text] = message.split('|');
 
 				return {
-					time: new Date(time),
+					// older safari versions do not support YYYY-MM-DD, that's why we replace the dashes
+					time: new Date(time.replace(/-/g, '/')),
 					process,
 					level,
 					logger,


### PR DESCRIPTION
Closes #509