### PR TITLE
Show bot name on mouse over for bot nickname

### DIFF
--- a/src/components/BotCard.vue
+++ b/src/components/BotCard.vue
@@ -6,7 +6,7 @@
 		<router-link v-else :to="{ name: 'bot', params: { bot: bot.name } }" tag="img" class="bot__avatar" :src="bot.avatarURL"></router-link>
 
 		<router-link tag="div" :to="{ name: 'bot', params: { bot: bot.name } }" class="bot__status">
-			<span v-if="bot.nickname && nicknames" class="bot__status-property bot__status-property--name">{{ bot.nickname }}</span>
+			<span v-if="bot.nickname && nicknames" class="bot__status-property bot__status-property--name" :title="bot.name">{{ bot.nickname }}</span>
 			<span v-else class="bot__status-property bot__status-property--name">{{ bot.name }}</span>
 			<span class="bot__status-property bot__status-property--text">{{ bot.statusText }}</span>
 		</router-link>

--- a/src/views/modals/Bot.vue
+++ b/src/views/modals/Bot.vue
@@ -9,7 +9,7 @@
 			</div>
 
 			<div class="bot-profile__meta">
-				<h3 v-if="bot.nickname && nicknames" class="bot-profile__name">
+				<h3 v-if="bot.nickname && nicknames" class="bot-profile__name" :title="bot.name">
 					{{ bot.nickname }}
 				</h3>
 				<h3 v-else class="bot-profile__name">


### PR DESCRIPTION
This should be useful if you have the option "Show nicknames" turned on but still want to have a way of knowing the bot name.