### PR TITLE
Hide the "Update" menu when UpdateChannel is 0

### DIFF
--- a/src/components/NavigationBrand.vue
+++ b/src/components/NavigationBrand.vue
@@ -9,7 +9,7 @@
 
 		<transition name="brand__menu">
 			<div v-if="brandMenu && authenticated" class="brand__menu">
-				<div class="brand__menu-item" @click="update">
+				<div v-if="updateChannel !== 0" class="brand__menu-item" @click="update">
 					<font-awesome-icon class="brand__menu-icon" icon="cloud-download-alt" fixed-width></font-awesome-icon>
 					<span>{{ $t('update') }}</span>
 				</div>
@@ -44,7 +44,8 @@
 		},
 		computed: mapGetters({
 			authenticated: 'auth/authenticated',
-			version: 'asf/version'
+			version: 'asf/version',
+			updateChannel: 'asf/updateChannel'
 		}),
 		methods: {
 			toggleBrandMenu() {


### PR DESCRIPTION
## Description
As per the ASF wiki:

>Setting UpdateChannel to 0 will entirely disable entire functionality related to updates, including update command.

https://github.com/JustArchiNET/ArchiSteamFarm/wiki/Configuration#updatechannel

## Screenshots
If `UpdateChannel` is `0`:
![image](https://user-images.githubusercontent.com/27077338/66256706-1155e380-e767-11e9-9e89-72202259173f.png)

If `UpdateChannel` is not `0`:
![image](https://user-images.githubusercontent.com/27077338/66256682-d0f66580-e766-11e9-85bb-bedb9caced0d.png)

## Checklist
<!--- Please go through this checklist before you submit your pull request. -->
- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
