### PR TITLE
Make sure we do not show the same release note twice

### DIFF
--- a/src/components/AsfReleases.vue
+++ b/src/components/AsfReleases.vue
@@ -72,7 +72,10 @@
 				try { rawReleases.push(await this.$http.get('www/github/release')); } catch (err) {}
 
 				if (!rawReleases[0].Stable) { // If the latest release is not stable, try fetching latest stable
-				  try { rawReleases.push(await this.$http.get('www/github/release/latest')); } catch (err) {}
+				  try {
+				    const release = await this.$http.get('www/github/release/latest');
+				    if (release.Version !== rawReleases[0].Version) rawReleases.push(release)
+					} catch (err) {}
         }
 
 				if (!rawReleases.find(release => release.version === this.version)) { // If the release list doesn't include our version, try fetching it explicitly

--- a/src/components/AsfReleases.vue
+++ b/src/components/AsfReleases.vue
@@ -68,26 +68,26 @@
 					if (version === this.version && timestamp > Date.now() - 24 * 60 * 60 * 1000) return releases;
 				}
 
-				const releases = await this.fetchReleases()
+				const releases = await this.fetchReleases();
 				storage.set('cache:releases', { timestamp: Date.now(), releases, version: this.version });
 				return releases;
 			},
 			async fetchReleases () {
-			  const releases = []
+				const releases = [];
 
-			  releases.push(await this.fetchRelease()); // Fetch latest release
-			  if (!releases[0] || !releases[0].stable) releases.push(await this.fetchRelease('latest')); // If the latest releases is not stable, fetch latest stable release
-			  if (!releases.some(release => release.version === this.version)) releases.push(await this.fetchRelease(this.version)); // If current version is neither latest nor latest stable, fetch it
+				releases.push(await this.fetchRelease()); // Fetch latest release
+				if (!releases[0] || !releases[0].stable) releases.push(await this.fetchRelease('latest')); // If the latest releases is not stable, fetch latest stable release
+				if (!releases.some(release => release.version === this.version)) releases.push(await this.fetchRelease(this.version)); // If current version is neither latest nor latest stable, fetch it
 
-			  return releases
+				return releases
 					.filter((value, index) => !!value && releases.findIndex(release => release.version === value.version) === index) // Clean the list in case any of the fetches failed, remove any duplicates
-					.sort((lhs, rhs) => compareVersion(rhs.version, lhs.version)) // Order the releases descending by version
+					.sort((lhs, rhs) => compareVersion(rhs.version, lhs.version)); // Order the releases descending by version
 			},
 			async fetchRelease (version = '') {
-			  try {
-          const release = await this.$http.get(`www/github/release/${version}`);
-          const publishedAt = new Date(release.ReleasedAt);
-          return { changelog: release.ChangelogHTML, stable: release.Stable, version: release.Version, publishedAt }
+				try {
+					const release = await this.$http.get(`www/github/release/${version}`);
+					const publishedAt = new Date(release.ReleasedAt);
+					return { changelog: release.ChangelogHTML, stable: release.Stable, version: release.Version, publishedAt };
 				} catch (err) {}
 			}
 		},

--- a/src/components/AsfReleases.vue
+++ b/src/components/AsfReleases.vue
@@ -68,36 +68,28 @@
 					if (version === this.version && timestamp > Date.now() - 24 * 60 * 60 * 1000) return releases;
 				}
 
-				const rawReleases = [];
-				try { rawReleases.push(await this.$http.get('www/github/release')); } catch (err) {}
-
-				if (!rawReleases[0].Stable) { // If the latest release is not stable, try fetching latest stable
-				  try {
-				    const release = await this.$http.get('www/github/release/latest');
-				    if (release.Version !== rawReleases[0].Version) rawReleases.push(release)
-					} catch (err) {}
-        }
-
-				if (!rawReleases.find(release => release.version === this.version)) { // If the release list doesn't include our version, try fetching it explicitly
-				  try { rawReleases.push(await this.$http.get(`www/github/release/${this.version}`)); } catch (err) {}
-        }
-
-				const releases = rawReleases
-					.sort((lhs, rhs) => compareVersion(rhs.Version, lhs.Version))
-					.map(release => {
-						const publishDate = new Date(release.ReleasedAt);
-
-						return {
-							changelog: release.ChangelogHTML,
-							stable: release.Stable,
-							version: release.Version,
-							publishDate,
-						};
-					});
-
+				const releases = await this.fetchReleases()
 				storage.set('cache:releases', { timestamp: Date.now(), releases, version: this.version });
 				return releases;
 			},
+			async fetchReleases () {
+			  const releases = []
+
+			  releases.push(await this.fetchRelease()); // Fetch latest release
+			  if (!releases[0] || !releases[0].stable) releases.push(await this.fetchRelease('latest')); // If the latest releases is not stable, fetch latest stable release
+			  if (!releases.some(release => release.version === this.version)) releases.push(await this.fetchRelease(this.version)); // If current version is neither latest nor latest stable, fetch it
+
+			  return releases
+					.filter((value, index) => !!value && releases.findIndex(release => release.version === value.version) === index) // Clean the list in case any of the fetches failed, remove any duplicates
+					.sort((lhs, rhs) => compareVersion(rhs.version, lhs.version)) // Order the releases descending by version
+			},
+			async fetchRelease (version = '') {
+			  try {
+          const release = await this.$http.get(`www/github/release/${version}`);
+          const publishedAt = new Date(release.ReleasedAt);
+          return { changelog: release.ChangelogHTML, stable: release.Stable, version: release.Version, publishedAt }
+				} catch (err) {}
+			}
 		},
 	};
 </script>


### PR DESCRIPTION
## Description
<!--- A clear and concise description of your changes. -->
<!--- If it fixes or closes an open issue, please link to the issue here. -->
Clean up the code a little, make sure there are no duplicates on the list if we store version in different format than the API returns. 

Closes #722 

## Screenshots
<!-- If applicable, add screenshots to visualize your changes. -->

## Additional information
<!-- Add any other information about the problem here. -->
From Botan's screens I suspect either the `version` might not yet be fetched from ASF API, or it was stored differently than the result of changelog endpoints. Either way, this PR should prevent duplicates to be shown.

I think in Botan's case the issue was caused by having the releases page set as default page of ASF-ui, which caused the requests fetching releases to be fired prior to loading the current version from `/asf` endpoint. We could prevent this (and similar) issues from happening by using a check in router's `beforeRoute` hook, that'd delay loading a page until we connect with ASF. 

## Checklist
<!--- Please go through this checklist before you submit your pull request. -->
- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
