### PR TITLE
Use OpenAPI definitions as configuration schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3415,11 +3415,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
-    },
     "check-types": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
@@ -3603,11 +3598,6 @@
           }
         }
       }
-    },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -4224,11 +4214,6 @@
         "which": "^1.2.9"
       }
     },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
-    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -4377,11 +4362,6 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
-    },
-    "dag-map": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz",
-      "integrity": "sha1-6DefBBAA7VYfxRVHXB7SyF7s6Nc="
     },
     "de-indent": {
       "version": "1.0.2",
@@ -6671,7 +6651,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -6758,29 +6739,6 @@
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
-      }
-    },
-    "is-invalid-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
-      "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
-      "requires": {
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
       }
     },
     "is-number": {
@@ -6872,14 +6830,6 @@
         "has-symbols": "^1.0.0"
       }
     },
-    "is-valid-path": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
-      "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
-      "requires": {
-        "is-invalid-path": "^0.1.0"
-      }
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -6937,21 +6887,6 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
-    },
-    "json-schema-deref-sync": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.13.0.tgz",
-      "integrity": "sha512-YBOEogm5w9Op337yb6pAT6ZXDqlxAsQCanM3grid8lMWNxRJO/zWEJi3ZzqDL8boWfwhTFym5EFrNgWwpqcBRg==",
-      "requires": {
-        "clone": "^2.1.2",
-        "dag-map": "~1.0.0",
-        "is-valid-path": "^0.1.1",
-        "lodash": "^4.17.13",
-        "md5": "~2.2.0",
-        "memory-cache": "~0.2.0",
-        "traverse": "~0.6.6",
-        "valid-url": "~1.0.9"
-      }
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -7063,7 +6998,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash-es": {
       "version": "4.17.15",
@@ -7134,16 +7070,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "md5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
-      "requires": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
-      }
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -7160,11 +7086,6 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
-    },
-    "memory-cache": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
-      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -9803,11 +9724,6 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
     },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
-    },
     "tryer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
@@ -10191,11 +10107,6 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
       "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
       "dev": true
-    },
-    "valid-url": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3020,6 +3020,16 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3405,6 +3415,11 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "check-types": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-8.0.3.tgz",
@@ -3588,6 +3603,11 @@
           }
         }
       }
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -4204,6 +4224,11 @@
         "which": "^1.2.9"
       }
     },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -4352,6 +4377,11 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
+    },
+    "dag-map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz",
+      "integrity": "sha1-6DefBBAA7VYfxRVHXB7SyF7s6Nc="
     },
     "de-indent": {
       "version": "1.0.2",
@@ -5688,6 +5718,13 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filesize": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
@@ -6634,8 +6671,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -6722,6 +6758,29 @@
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
+      }
+    },
+    "is-invalid-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
+      "requires": {
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
       }
     },
     "is-number": {
@@ -6813,6 +6872,14 @@
         "has-symbols": "^1.0.0"
       }
     },
+    "is-valid-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
+      "requires": {
+        "is-invalid-path": "^0.1.0"
+      }
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -6870,6 +6937,21 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
+    },
+    "json-schema-deref-sync": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.13.0.tgz",
+      "integrity": "sha512-YBOEogm5w9Op337yb6pAT6ZXDqlxAsQCanM3grid8lMWNxRJO/zWEJi3ZzqDL8boWfwhTFym5EFrNgWwpqcBRg==",
+      "requires": {
+        "clone": "^2.1.2",
+        "dag-map": "~1.0.0",
+        "is-valid-path": "^0.1.1",
+        "lodash": "^4.17.13",
+        "md5": "~2.2.0",
+        "memory-cache": "~0.2.0",
+        "traverse": "~0.6.6",
+        "valid-url": "~1.0.9"
+      }
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -6981,8 +7063,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash-es": {
       "version": "4.17.15",
@@ -7053,6 +7134,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -7069,6 +7160,11 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
+    },
+    "memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -7356,6 +7452,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -9700,6 +9803,11 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
     "tryer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
@@ -10084,6 +10192,11 @@
       "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
       "dev": true
     },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -10426,7 +10539,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -10844,7 +10961,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
 		"copy-to-clipboard": "^3.3.1",
 		"flat": "^5.0.0",
 		"humanize-duration": "^3.23.1",
-		"json-schema-deref-sync": "^0.13.0",
 		"lodash-es": "^4.17.15",
 		"plurals-cldr": "^1.0.4",
 		"svg-country-flags": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"copy-to-clipboard": "^3.3.1",
 		"flat": "^5.0.0",
 		"humanize-duration": "^3.23.1",
+		"json-schema-deref-sync": "^0.13.0",
 		"lodash-es": "^4.17.15",
 		"plurals-cldr": "^1.0.4",
 		"svg-country-flags": "^1.2.7",

--- a/src/components/ConfigEditor.vue
+++ b/src/components/ConfigEditor.vue
@@ -44,14 +44,14 @@
 				required: true
 			},
 			categories: Array,
-			descriptions: Object,
 			extendedFields: Object
 		},
 		computed: {
 			uncategorizedFields() {
 				if (!this.categories) return this.fields;
 
-				const categorizedFields = this.categories.map(category => category.fields).reduce((categorizedFields, categoryFields) => [...categorizedFields, ...categoryFields], []);
+				const categorizedFields = this.categories.map(category => category.fields)
+						.reduce((categorizedFields, categoryFields) => [...categorizedFields, ...categoryFields], []);
 
 				return this.fields.filter(field => !categorizedFields.includes(field.param));
 			},
@@ -60,7 +60,8 @@
 					if (!this.categories) return [];
 					const category = this.categories.find(({ name }) => name === categoryName);
 					if (!category) return [];
-					return this.getFields(category.fields).sort((a, b) => category.fields.indexOf(a.paramName) - category.fields.indexOf(b.paramName));
+					return this.getFields(category.fields)
+							.sort((a, b) => category.fields.indexOf(a.paramName) - category.fields.indexOf(b.paramName));
 				};
 			},
 			isValid() {
@@ -76,27 +77,24 @@
 		},
 		methods: {
 			componentFromField(field) {
+				console.log({ ...field });
+
 				switch (field.type) {
 					case 'string':
-					case 'uint64':
+						if (field.enum) {
+							if (field.format === 'flags') return InputFlag;
+							return InputEnum;
+						}
+
 						return InputString;
 					case 'boolean':
 						return InputBoolean;
-					case 'uint32':
-					case 'uint16':
-					case 'byte':
+					case 'integer':
+						if (field.format === 'int64') return InputString;
 						return InputNumber;
-					case 'flag':
-						return InputFlag;
-					case 'enum':
-						return InputEnum;
-					case 'hashSet':
-					case 'list':
-						if (['enum'].includes(field.values.type)) return field.type === 'list' ? InputList : InputSet;
-						if (['byte', 'uint16', 'uint32', 'uint64', 'string'].includes(field.values.type)) return InputTag;
-						return InputUnknown;
-					case 'dictionary':
-						return InputDictionary;
+					case 'array':
+						if (field.items.type === 'enum') return InputSet;
+						return InputTag;
 					default:
 						return InputUnknown;
 				}
@@ -129,7 +127,8 @@
 					case 'list':
 						return a.length === b.length && a.every((item, index) => item === b[index]);
 					case 'dictionary':
-						return Object.keys(a).length === Object.keys(b).length && Object.keys(a).every(key => a[key] === b[key]);
+						return Object.keys(a).length === Object.keys(b).length && Object.keys(a)
+								.every(key => a[key] === b[key]);
 				}
 
 				return false;
@@ -141,7 +140,8 @@
 				this.$el.style.setProperty('--label-width', 'auto');
 
 				this.$nextTick(() => {
-					const labelWidth = Math.max(...Array.from(this.$el.querySelectorAll('.form-item__label')).map(el => Math.ceil(parseFloat(getComputedStyle(el).width))));
+					const labelWidth = Math.max(...Array.from(this.$el.querySelectorAll('.form-item__label'))
+							.map(el => Math.ceil(parseFloat(getComputedStyle(el).width))));
 					this.$el.style.setProperty('--label-width', `${labelWidth}px`);
 				});
 			}

--- a/src/components/ConfigEditor.vue
+++ b/src/components/ConfigEditor.vue
@@ -77,24 +77,25 @@
 		},
 		methods: {
 			componentFromField(field) {
-				console.log({ ...field });
+				if (field.format === 'flags') return InputFlag;
+				if (field.enum) return InputEnum;
 
 				switch (field.type) {
 					case 'string':
-						if (field.enum) {
-							if (field.format === 'flags') return InputFlag;
-							return InputEnum;
-						}
-
 						return InputString;
 					case 'boolean':
 						return InputBoolean;
 					case 'integer':
-						if (field.format === 'int64') return InputString;
 						return InputNumber;
 					case 'array':
-						if (field.items.type === 'enum') return InputSet;
+						if (field.items.enum) {
+							if (field.uniqueItems) return InputSet;
+							return InputList;
+						}
+
 						return InputTag;
+					case 'object':
+						return InputDictionary;
 					default:
 						return InputUnknown;
 				}

--- a/src/components/ConfigFields/Input.vue
+++ b/src/components/ConfigFields/Input.vue
@@ -21,9 +21,6 @@
 			};
 		},
 		computed: {
-			defaultValue() {
-				return this.schema.defaultValue;
-			},
 			label() {
 				return this.schema.label || this.schema.param || this.schema.paramName;
 			},
@@ -31,7 +28,7 @@
 				return this.schema.paramName;
 			},
 			placeholder() {
-				return this.schema.placeholder || this.schema.defaultValue;
+				return this.schema.placeholder;
 			},
 			description() {
 				return this.schema.description;

--- a/src/components/ConfigFields/Input.vue
+++ b/src/components/ConfigFields/Input.vue
@@ -13,7 +13,7 @@
 			currentValue: true
 		},
 		data() {
-			const initialValue = typeof this.currentValue !== 'undefined' ? this.currentValue : this.schema.defaultValue;
+			const initialValue = typeof this.currentValue !== 'undefined' ? this.currentValue : null;
 
 			return {
 				value: typeof initialValue === 'object' ? JSON.parse(JSON.stringify(initialValue)) : initialValue,

--- a/src/components/ConfigFields/InputEnum.vue
+++ b/src/components/ConfigFields/InputEnum.vue
@@ -4,9 +4,7 @@
 
 		<div class="form-item__value">
 			<select :id="field" v-model="value" class="form-item__input" :name="field">
-				<option v-for="(enumValue, name) in values" v-if="!(name === 'Max' && isLastValue(enumValue))" :value="enumValue">
-					{{ name }}
-				</option>
+				<option v-for="value in values" :value="value">{{ value }}</option>
 			</select>
 		</div>
 
@@ -22,12 +20,7 @@
 		mixins: [Input],
 		computed: {
 			values() {
-				return this.schema.values;
-			}
-		},
-		methods: {
-			isLastValue(value) {
-				return value === Math.max(...Object.values(this.values));
+				return this.schema.enum;
 			}
 		}
 	};

--- a/src/components/ConfigFields/InputEnum.vue
+++ b/src/components/ConfigFields/InputEnum.vue
@@ -4,7 +4,7 @@
 
 		<div class="form-item__value">
 			<select :id="field" v-model="value" class="form-item__input" :name="field">
-				<option v-for="value in values" :value="value">{{ value }}</option>
+				<option v-for="{ label, value } in enums" :value="value">{{ label }}</option>
 			</select>
 		</div>
 
@@ -19,8 +19,8 @@
 		name: 'input-enum',
 		mixins: [Input],
 		computed: {
-			values() {
-				return this.schema.enum;
+			enums() {
+				return Object.entries(this.schema['x-definition']).map(([label, value]) => ({ label, value }))
 			}
 		}
 	};

--- a/src/components/ConfigFields/InputFlag.vue
+++ b/src/components/ConfigFields/InputFlag.vue
@@ -4,11 +4,11 @@
 
 		<div class="form-item__value">
 			<div class="input-option__field">
-				<select :id="field" v-model="flagValue" class="form-item__input">
-					<option v-for="(flagValue, name) in flags" v-show="flagValue === 0 || !((value & flagValue) === flagValue)" :value="flagValue">
-						{{ name }}
-					</option>
+				<select :id="field" v-model="flagValue" class="form-item__input" :disabled="!availableFlags.length">
+					<option v-for="{ label, flag } in availableFlags" :value="flag">{{ label }}</option>
+					<option :value="null" disabled v-if="!availableFlags.length">{{ $t('input-all-selected') }}</option>
 				</select>
+
 				<button class="button" @click.prevent="addFlag">
 					{{ $t('add') }}
 				</button>
@@ -33,27 +33,46 @@
 		mixins: [Input],
 		data() {
 			return {
-				flagValue: this.schema.defaultValue
+				flagValue: null
 			};
 		},
 		computed: {
+			availableFlags() {
+				return this.flags
+						.filter(({ flag }) => (flag & this.value) !== flag);
+			},
 			flags() {
-				return this.schema.values;
+				return Object.entries(this.schema['x-definition'])
+						.map(([label, flag]) => ({
+							label,
+							flag
+						}))
+						.filter(({ flag }) => flag % 2 === 0 || flag === 1);
 			}
 		},
+		created () {
+			this.setDefaultFlag()
+		},
 		methods: {
+			setDefaultFlag() {
+				this.flagValue = !this.availableFlags.length ? null : this.availableFlags[0].flag;
+			},
 			addFlag() {
+				if (!this.flagValue) return;
 				if (!this.flagValue && this.flagValue !== 0) return;
-
 				if (this.flagValue === 0) this.value = 0;
+
 				this.value |= this.flagValue;
-				this.flagValue = this.schema.defaultValue;
+				this.setDefaultFlag();
 			},
 			removeFlag(value) {
 				this.value &= ~value;
+				if (!this.flagValue) this.setDefaultFlag()
 			},
 			resolveFlagName(value) {
-				return Object.keys(this.flags).find(key => this.flags[key] === value);
+				const flag = this.flags.find(({ flag }) => flag === value);
+				if (!flag) return value;
+				return flag.label;
 			}
 		}
 	};

--- a/src/components/ConfigFields/InputList.vue
+++ b/src/components/ConfigFields/InputList.vue
@@ -5,12 +5,8 @@
 		<div class="form-item__value">
 			<div class="input-option__field">
 				<select :id="field" v-model="element" class="form-item__input" :disabled="!availableEnumValues.length">
-					<option v-for="(enumValue, name) in enumValues" v-show="!value.includes(enumValue)" :value="enumValue">
-						{{ name }}
-					</option>
-					<option v-if="!availableEnumValues.length" :value="undefined" disabled>
-						{{ $t('input-all-selected') }}
-					</option>
+					<option v-for="value in enumValues" v-show="!value.includes(value)" :value="value">{{ value }}</option>
+					<option v-if="!availableEnumValues.length" :value="undefined" disabled>{{ $t('input-all-selected') }}</option>
 				</select>
 
 				<button class="button" @click.prevent="addElement">
@@ -20,7 +16,7 @@
 
 			<div class="input-option__items">
 				<button v-for="(item, index) in value" class="button input-option__item" @click.prevent="removeElement(index)">
-					{{ resolveOption(item) }}
+					{{ item }}
 				</button>
 			</div>
 		</div>
@@ -44,15 +40,15 @@
 			availableEnumValues() {
 				const availableEnumValues = [];
 
-				for (const key of Object.keys(this.enumValues)) {
-					if (this.value.includes(this.enumValues[key])) continue;
-					availableEnumValues.push(this.enumValues[key]);
+				for (const value of this.enumValues) {
+					if (this.value.includes(value)) continue;
+					availableEnumValues.push(value);
 				}
 
 				return availableEnumValues;
 			},
 			enumValues() {
-				return this.schema.values.values;
+				return this.schema.enum;
 			}
 		},
 		created() {
@@ -72,9 +68,6 @@
 			removeElement(index) {
 				this.value.splice(index, 1);
 				this.element = this.getDefaultElement();
-			},
-			resolveOption(value) {
-				return Object.keys(this.enumValues).find(key => this.enumValues[key] === value);
 			}
 		}
 	};

--- a/src/components/ConfigFields/InputNumber.vue
+++ b/src/components/ConfigFields/InputNumber.vue
@@ -3,7 +3,7 @@
 		<input-label :label="label" :has-description="hasDescription"></input-label>
 
 		<div class="form-item__value">
-			<input :id="field" v-model.number="value" class="form-item__input" type="number" :name="field" :placeholder="placeholder" @blur="onBlur">
+			<input :id="field" v-model.number="value" class="form-item__input" type="number" :name="field" :placeholder="placeholder">
 			<span v-if="hasErrors" class="form-item__error">{{ errorText }}</span>
 		</div>
 
@@ -16,11 +16,6 @@
 
 	export default {
 		name: 'input-number',
-		mixins: [Input],
-		methods: {
-			onBlur() {
-				if (this.value === '') this.value = this.defaultValue;
-			}
-		}
+		mixins: [Input]
 	};
 </script>

--- a/src/components/ConfigFields/InputSet.vue
+++ b/src/components/ConfigFields/InputSet.vue
@@ -5,12 +5,8 @@
 		<div class="form-item__value">
 			<div class="input-option__field">
 				<select :id="field" v-model="element" class="form-item__input" :disabled="!availableEnumValues.length">
-					<option v-for="(enumValue, name) in enumValues" v-show="!value.includes(enumValue)" :value="enumValue">
-						{{ name }}
-					</option>
-					<option v-if="!availableEnumValues.length" :value="undefined" disabled>
-						{{ $t('input-all-selected') }}
-					</option>
+					<option v-for="{ label, value } in availableEnumValues" :value="value">{{ label }}</option>
+					<option v-if="!availableEnumValues.length" :value="null" disabled>{{ $t('input-all-selected') }}</option>
 				</select>
 
 				<button class="button" @click.prevent="addElement">
@@ -20,7 +16,7 @@
 
 			<div class="input-option__items">
 				<button v-for="(item, index) in value" class="button input-option__item" @click.prevent="removeElement(index)">
-					{{ resolveOption(item) }}
+					{{ resolveValue(item) }}
 				</button>
 			</div>
 		</div>
@@ -42,17 +38,18 @@
 		},
 		computed: {
 			availableEnumValues() {
-				const availableEnumValues = [];
-
-				for (const key of Object.keys(this.enumValues)) {
-					if (this.value.includes(this.enumValues[key])) continue;
-					availableEnumValues.push(this.enumValues[key]);
-				}
-
-				return availableEnumValues;
+				return this.enumValues.filter(({ value }) => !this.value.includes(value))
 			},
 			enumValues() {
-				return this.schema.values.values;
+				return Object.entries(this.schema.items['x-definition'])
+          .map(([label, value]) => ({ label, value }))
+			},
+			resolveValue() {
+				return value => {
+					const enumValue = this.enumValues.find(({ value: enumValue }) => value === enumValue)
+					if (!enumValue) return value
+					return enumValue.label
+        }
 			}
 		},
 		created() {
@@ -61,22 +58,20 @@
 		},
 		methods: {
 			getDefaultElement() {
-				return this.availableEnumValues[0];
+				return this.availableEnumValues[0] ? this.availableEnumValues[0].value : null;
 			},
 			addElement() {
-				if (!this.element && this.element !== 0) return;
+				if (!this.element && this.element !== 0) return
 				if (this.value.includes(this.element)) return;
 
 				this.value.push(this.element);
 				this.value.sort();
+
 				this.element = this.getDefaultElement();
 			},
 			removeElement(index) {
 				this.value.splice(index, 1);
 				this.element = this.getDefaultElement();
-			},
-			resolveOption(value) {
-				return Object.keys(this.enumValues).find(key => this.enumValues[key] === value);
 			}
 		}
 	};

--- a/src/components/ConfigFields/InputString.vue
+++ b/src/components/ConfigFields/InputString.vue
@@ -3,7 +3,7 @@
 		<input-label :label="label" :has-description="hasDescription"></input-label>
 
 		<div class="form-item__value">
-			<input :id="field" v-model="value" class="form-item__input" type="text" :name="field" :placeholder="placeholder" @blur="onBlur" @keypress="onKeyPress">
+			<input :id="field" v-model="value" class="form-item__input" type="text" :name="field" :placeholder="placeholder" @keypress="onKeyPress">
 			<span v-if="hasErrors" class="form-item__error">{{ errorText }}</span>
 		</div>
 
@@ -18,9 +18,6 @@
 		name: 'input-string',
 		mixins: [Input],
 		methods: {
-			onBlur() {
-				if (this.value === '') this.value = this.defaultValue;
-			},
 			onKeyPress($event) {
 				if (this.schema.type !== 'uint64') return true;
 

--- a/src/components/ConfigFields/InputTag.vue
+++ b/src/components/ConfigFields/InputTag.vue
@@ -43,7 +43,7 @@
 				return ['string'].includes(this.schema.items.type);
 			},
 			isNumber() {
-				return ['uint32', 'uint16'].includes(this.schema.items.type);
+				return ['integer'].includes(this.schema.items.type);
 			},
 			errors() {
 				if (validator.hasOwnProperty(this.schema.items.type)) return validator[this.schema.items.type](this.element);

--- a/src/components/ConfigFields/InputTag.vue
+++ b/src/components/ConfigFields/InputTag.vue
@@ -9,12 +9,15 @@
 						<span class="form-item__tag-value">{{ item }}</span>
 						<font-awesome-icon class="form-item__tag-remove" icon="times"></font-awesome-icon>
 					</button>
+
 					<input v-model="element" class="form-item__input form-item__input--tag" type="text" @keydown="onKeyDown" @focus="onFocus" @blur="onBlur">
 				</div>
+
 				<button class="button" @click.prevent="addElement">
 					{{ $t('add') }}
 				</button>
 			</div>
+
 			<span v-if="hasErrors" class="form-item__error">{{ errorText }}</span>
 		</div>
 
@@ -37,13 +40,13 @@
 		},
 		computed: {
 			isString() {
-				return ['string', 'uint64'].includes(this.schema.values.type);
+				return ['string'].includes(this.schema.items.type);
 			},
 			isNumber() {
-				return ['uint32', 'uint16'].includes(this.schema.values.type);
+				return ['uint32', 'uint16'].includes(this.schema.items.type);
 			},
 			errors() {
-				if (validator.hasOwnProperty(this.schema.values.type)) return validator[this.schema.values.type](this.element);
+				if (validator.hasOwnProperty(this.schema.items.type)) return validator[this.schema.items.type](this.element);
 				return [];
 			},
 			isValid() {

--- a/src/utils/swagger/dereference.js
+++ b/src/utils/swagger/dereference.js
@@ -1,0 +1,23 @@
+import { cloneDeep, get, isObject } from 'lodash-es';
+
+function isRef(node) {
+	return node.$ref;
+}
+
+function resolveRef(path, schema) {
+	const lodashPath = path.substr(2).replace(/\//g, '.');
+	return get(schema, lodashPath);
+}
+
+function resolve(tree, schema) {
+	for (const key of Object.keys(tree)) {
+		if (isRef(tree[key])) tree[key] = resolveRef(tree[key].$ref, schema);
+		if (isObject(tree[key])) resolve(tree[key], schema);
+	}
+}
+
+export function dereference(schema) {
+	const localSchema = cloneDeep(schema);
+	resolve(localSchema, localSchema);
+	return localSchema;
+}

--- a/src/utils/swagger/parse.js
+++ b/src/utils/swagger/parse.js
@@ -1,0 +1,16 @@
+import { dereference } from './dereference';
+import axios from 'axios';
+
+const endpoint = 'http://localhost:8080/swagger/ASF/swagger.json';
+
+export async function getTypes() {
+	return await axios.get(endpoint)
+		.then(response => response.data)
+		.then(schema => dereference(schema))
+		.then(schema => schema.components.schemas);
+}
+
+export async function getType(name) {
+	const { [name]: type } = await getTypes();
+	return type.properties;
+}

--- a/src/views/GlobalConfig.vue
+++ b/src/views/GlobalConfig.vue
@@ -69,23 +69,23 @@
 			displayCategories: 'settings/displayCategories'
 		}),
 		async created() {
-			const [
-				{ GlobalConfig: model },
-				scheme,
-				descriptions
-			] = await Promise.all([
-				this.$http.get('asf'),
+			const [model, schema, descriptions] = await Promise.all([
+				this.getModel(),
 				getType('GlobalConfig'),
 				loadParameterDescriptions(this.version, this.$i18n.locale)
 			]);
 
-			Object.keys(scheme).forEach(name => {
-				if (name.startsWith('s_')) delete scheme[name.substr(2)]
+			Object.keys(schema).forEach(name => {
+				if (name.startsWith('s_')) {
+					const paramName = name.substr(2);
+					delete model[paramName]
+					delete schema[paramName]
+				}
 			});
 
-			this.fields = Object.keys(scheme).map(name => ({
-				description: descriptions[name],
-				...scheme[name],
+			this.fields = Object.keys(schema).map(name => ({
+				description: descriptions[name.replace('s_', '')],
+				...schema[name],
 				param: name.replace('s_', ''),
 				paramName: name
 			}));
@@ -95,6 +95,10 @@
 			await getType('BotConfig').then(c => console.log(c))
 		},
 		methods: {
+			async getModel () {
+				const { GlobalConfig: model } = await this.$http.get('asf');
+				return model;
+			},
 			async onSave() {
 				if (this.saving) return;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,7 +90,8 @@ module.exports = {
 			'/api': {
 				target: 'http://localhost:1242',
 				ws: true
-			}
+			},
+			'/swagger': { target: 'http://localhost:1242' }
 		}
 	}
 };


### PR DESCRIPTION
## Description
As title says, the use of `GET /Type` and `GET /Structure` was replaced by parsing OpenAPI documentation available in `/swagger/ASF/swagger.json`. I focused on making existing components work with the mew definition and not much else, to reduce scope of the PR.

Please test it with latest ASF release ([**V4.2.3.4**](https://github.com/JustArchiNET/ArchiSteamFarm/releases/tag/4.2.3.4)), as it relies on introduced changes.

## Additional information
Closes #871

The code style may be not consistent with the project, our eslint settings are very scuffed (eg. existing code doesn't follow latest rules from plugins) and fixing the code style is out of the scope for this PR.

## TODO
- [ ] Default model for new bot - currently we use empty object as a model, which breaks the inputs and sets wrong defaults on fields which didn't break.
- [ ] Extensive testing - last thing we want is to break existing configs, and this change has full potential to do so
- [ ] Adjust UI settings to follow new schema definitions

## Follow up
- Cleanup input logic, normalize variable names
- Abstract schema preparation - currently _almost_ the same logic is repeated in at least 3 components
- Cleanup unused code left from parsing old definitions

## Checklist
<!--- Please go through this checklist before you submit your pull request. -->
- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [ ] My code follows the code style of this project
- [x] I have performed a self-review of my own code
