### PR TITLE
Ensure that getCommitHash() always returns 7 chars

### DIFF
--- a/scripts/getCommitHash.js
+++ b/scripts/getCommitHash.js
@@ -2,7 +2,7 @@ const { execSync } = require('child_process');
 
 module.exports = function getCommitHash() {
   try {
-    return execSync('git rev-parse --short HEAD').toString();
+    return execSync('git rev-parse --short=7 HEAD').toString();
   } catch (err) {
     return '0000000';
   }


### PR DESCRIPTION
## Description
<!--- A clear and concise description of your changes. -->
<!--- If it fixes or closes an open issue, please link to the issue here. -->

`--short` is configuration-dependent, we probably don't want this to output `32` or whatever amount of characters just because somebody configured his `git` to do that. This handles this scenario.

## Screenshots
<!-- If applicable, add screenshots to visualize your changes. -->

## Additional information
<!-- Add any other information about the problem here. -->

## Checklist
<!--- Please go through this checklist before you submit your pull request. -->
- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
