### PR TITLE
Replace `webpack-dev-server` with `webpack serve` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Standalone web interface for ASF",
   "scripts": {
-    "start": "webpack-dev-server --config webpack/config.js --hot --open",
+    "start": "webpack serve --config webpack/config.js",
     "lint": "eslint --ext .vue,.js src scripts webpack",
     "lint-fix": "eslint --ext .vue,.js src scripts webpack --fix",
     "build": "webpack --config webpack/config.prod.js",


### PR DESCRIPTION
## Description
<!--- A clear and concise description of your changes. -->
<!--- If it fixes or closes an open issue, please link to the issue here. -->
`webpack-dev-server` standalone use along webpack-cli 4 have been discouraged as per webpack/webpack-dev-server#2424

## Checklist
<!--- Please go through this checklist before you submit your pull request. -->
- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
