### PR TITLE
Only send one request per hour to 'www/send'

### DIFF
--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -4,22 +4,23 @@ import { set, get } from './storage';
 
 export const ui = { gitCommitHash: APP_HASH };
 
+async function isReleaseAvailable() {
+  const updateChannel = (asf.updateChannel === UPDATECHANNEL.EXPERIMENTAL) ? 'releases' : 'releases/latest';
+  const latestReleaseRaw = await http.post('www/send', { url: `https://api.github.com/repos/JustArchiNET/ArchiSteamFarm/${updateChannel}` });
+  set('last-checked-for-update', Date.now());
+
+  const latestReleaseVersion = JSON.parse(latestReleaseRaw);
+  if (!latestReleaseVersion) return false;
+
+  const latestVersion = (asf.updateChannel === UPDATECHANNEL.EXPERIMENTAL) ? latestReleaseVersion[0].tag_name : latestReleaseVersion.tag_name;
+  set('latest-release', latestVersion);
+
+  return (latestVersion > asf.version);
+}
+
 export async function newReleaseAvailable() {
-  try {
-    const lastChecked = get('last-checked-for-update');
-    if (lastChecked && (lastChecked > (Date.now() - 60 * 60 * 1000))) return false;
+  const lastChecked = get('last-checked-for-update');
+  if (lastChecked && (lastChecked > (Date.now() - 60 * 60 * 1000))) return false;
 
-    const updateChannel = (asf.updateChannel === UPDATECHANNEL.EXPERIMENTAL) ? 'releases' : 'releases/latest';
-    const latestReleaseRaw = await http.post('www/send', { url: `https://api.github.com/repos/JustArchiNET/ArchiSteamFarm/${updateChannel}` });
-    set('last-checked-for-update', Date.now());
-
-    const latestReleaseVersion = JSON.parse(latestReleaseRaw);
-    if (!latestReleaseVersion) return false;
-
-    const latestVersion = (asf.updateChannel === UPDATECHANNEL.EXPERIMENTAL) ? latestReleaseVersion[0].tag_name : latestReleaseVersion.tag_name;
-    set('latest-release', latestVersion);
-    return (latestVersion > asf.version);
-  } catch (err) {
-    console.warn(err.message);
-  }
+  return isReleaseAvailable();
 }

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -6,13 +6,13 @@ export const ui = { gitCommitHash: APP_HASH };
 
 async function isReleaseAvailable() {
   const updateChannel = (asf.updateChannel === UPDATECHANNEL.EXPERIMENTAL) ? 'releases' : 'releases/latest';
-  const latestReleaseRaw = await http.post('www/send', { url: `https://api.github.com/repos/JustArchiNET/ArchiSteamFarm/${updateChannel}` });
+  const response = await http.post('www/send', { url: `https://api.github.com/repos/JustArchiNET/ArchiSteamFarm/${updateChannel}` });
   set('last-checked-for-update', Date.now());
 
-  const latestReleaseVersion = JSON.parse(latestReleaseRaw);
-  if (!latestReleaseVersion) return false;
+  const latestRelease = JSON.parse(response);
+  if (!latestRelease) return false;
 
-  const latestVersion = (asf.updateChannel === UPDATECHANNEL.EXPERIMENTAL) ? latestReleaseVersion[0].tag_name : latestReleaseVersion.tag_name;
+  const latestVersion = (asf.updateChannel === UPDATECHANNEL.EXPERIMENTAL) ? latestRelease[0].tag_name : latestRelease.tag_name;
   set('latest-release', latestVersion);
 
   return (latestVersion > asf.version);

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -1,17 +1,29 @@
 import * as http from '../plugins/http';
 import { state as asf, UPDATECHANNEL } from '../store/modules/asf';
-import { set } from './storage';
+import { set, get } from './storage';
 
 export const ui = { gitCommitHash: APP_HASH };
 
 export async function newReleaseAvailable() {
-  const updateChannel = (asf.updateChannel === UPDATECHANNEL.EXPERIMENTAL) ? 'releases' : 'releases/latest';
-  const latestReleaseRaw = await http.post('www/send', { url: `https://api.github.com/repos/JustArchiNET/ArchiSteamFarm/${updateChannel}` });
-  const latestReleaseVersion = JSON.parse(latestReleaseRaw);
+  try {
+    const lastChecked = get('last-checked-for-update');
 
-  if (!latestReleaseVersion) return;
+    if (lastChecked) {
+      const currentTimestamp = Date.now() - 60 * 60 * 1000;
+      if (lastChecked > currentTimestamp) return false;
+    }
 
-  const latestVersion = (asf.updateChannel === UPDATECHANNEL.EXPERIMENTAL) ? latestReleaseVersion[0].tag_name : latestReleaseVersion.tag_name;
-  set('latest-release', latestVersion);
-  return (latestVersion > asf.version);
+    const updateChannel = (asf.updateChannel === UPDATECHANNEL.EXPERIMENTAL) ? 'releases' : 'releases/latest';
+    const latestReleaseRaw = await http.post('www/send', { url: `https://api.github.com/repos/JustArchiNET/ArchiSteamFarm/${updateChannel}` });
+    set('last-checked-for-update', Date.now());
+
+    const latestReleaseVersion = JSON.parse(latestReleaseRaw);
+    if (!latestReleaseVersion) return false;
+
+    const latestVersion = (asf.updateChannel === UPDATECHANNEL.EXPERIMENTAL) ? latestReleaseVersion[0].tag_name : latestReleaseVersion.tag_name;
+    set('latest-release', latestVersion);
+    return (latestVersion > asf.version);
+  } catch (err) {
+    console.warn(err.message);
+  }
 }

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -7,11 +7,7 @@ export const ui = { gitCommitHash: APP_HASH };
 export async function newReleaseAvailable() {
   try {
     const lastChecked = get('last-checked-for-update');
-
-    if (lastChecked) {
-      const currentTimestamp = Date.now() - 60 * 60 * 1000;
-      if (lastChecked > currentTimestamp) return false;
-    }
+    if (lastChecked && (lastChecked > (Date.now() - 60 * 60 * 1000))) return false;
 
     const updateChannel = (asf.updateChannel === UPDATECHANNEL.EXPERIMENTAL) ? 'releases' : 'releases/latest';
     const latestReleaseRaw = await http.post('www/send', { url: `https://api.github.com/repos/JustArchiNET/ArchiSteamFarm/${updateChannel}` });


### PR DESCRIPTION
## Description
Fixes #1150 

## Additional information
I've set the limit to one request per hour. This means that ASF-ui will now check every hour (if the mounted event for the footer gets triggered aka. page reload) for an update. This could also be a potential new UI configuration. So user can set it to 1 hour, 1 day or turn it off.

## Checklist
<!--- Please go through this checklist before you submit your pull request. -->
- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
