### PR TITLE
Implement #1449 - speed up configuration workflow

### DIFF
--- a/src/components/ConfigEditor.vue
+++ b/src/components/ConfigEditor.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="config-editor">
-    <template v-if="categories">
-      <ConfigCategory v-for="category in categories" v-if="categoryFields(category.name).length" :key="category.name" :name="category.name">
-        <component :is="componentFromField(field)" v-for="field in categoryFields(category.name)" :key="field.param" class="form-item--config" :schema="field" :current-value="model[field.paramName]" @update="updateModel"></component>
+    <template v-if="nonEmptyCategories">
+      <ConfigCategory v-for="category in nonEmptyCategories" :key="category.name" :name="category.name">
+        <component :is="componentFromField(field)" v-for="field in categoryFields(category.name)" :key="field.param" class="form-item--config" :schema="field" :currentValue="model[field.paramName]" @update="updateModel"></component>
       </ConfigCategory>
 
       <ConfigCategory v-if="uncategorizedFields.length" key="Other" :name="$t('other')">
-        <component :is="componentFromField(field)" v-for="field in uncategorizedFields" :key="field.param" class="form-item--config" :schema="field" :current-value="model[field.paramName]" @update="updateModel"></component>
+        <component :is="componentFromField(field)" v-for="field in uncategorizedFields" :key="field.param" class="form-item--config" :schema="field" :currentValue="model[field.paramName]" @update="updateModel"></component>
       </ConfigCategory>
     </template>
 
-    <template v-if="!categories">
+    <template v-if="!nonEmptyCategories">
       <fieldset class="config-uncategorized">
-        <component :is="componentFromField(field)" v-for="field in uncategorizedFields" :key="field.param" class="form-item--config" :schema="field" :current-value="model[field.paramName]" @update="updateModel"></component>
+        <component :is="componentFromField(field)" v-for="field in uncategorizedFields" :key="field.param" class="form-item--config" :schema="field" :currentValue="model[field.paramName]" @update="updateModel"></component>
       </fieldset>
     </template>
   </div>
@@ -53,6 +53,11 @@
       },
     },
     computed: {
+      nonEmptyCategories() {
+        if (!this.categories) return this.categories;
+
+        return this.categories.filter(category => this.categoryFields(category.name).length);
+      },
       uncategorizedFields() {
         if (!this.categories) return this.fields;
 

--- a/src/components/ConfigFields/InputFlag.vue
+++ b/src/components/ConfigFields/InputFlag.vue
@@ -5,7 +5,7 @@
     <div class="form-item__value">
       <select :id="field" v-model="selectedElement" class="form-item__input" @change="addFlag($event.target.value)">
         <!-- TODO - add that text to localization instead of hardcoding it -->
-        <option :value="null" disabled selected hidden>Select Option</option>
+        <option :value="null" disabled selected hidden>{{ $t('input-select-enum-value') }}</option>
         <option v-for="(enumValue, name) in flags" v-show="enumValue === 0 || !((value & enumValue) === enumValue)" :key="name" :value="enumValue">
           {{ name }}
         </option>

--- a/src/components/ConfigFields/InputFlag.vue
+++ b/src/components/ConfigFields/InputFlag.vue
@@ -4,7 +4,6 @@
 
     <div class="form-item__value">
       <select :id="field" v-model="selectedElement" class="form-item__input" @change="addFlag($event.target.value)">
-        <!-- TODO - add that text to localization instead of hardcoding it -->
         <option :value="null" disabled selected hidden>{{ $t('input-select-enum-value') }}</option>
         <option v-for="(enumValue, name) in flags" v-show="enumValue === 0 || !((value & enumValue) === enumValue)" :key="name" :value="enumValue">
           {{ name }}

--- a/src/components/ConfigFields/InputFlag.vue
+++ b/src/components/ConfigFields/InputFlag.vue
@@ -42,16 +42,14 @@
         return [...Array(32).keys()].map(i => 1 << i).filter(val => this.value & val);
       },
       addFlag(input) {
-        if (typeof (input) !== typeof (0)) {
-          input = parseInt(input, 10);
-        }
+        const parsedInput = typeof (input) !== (typeof (0)) ? parseInt(input, 10) : input;
 
-        if (!input && input !== 0) return;
+        if (!parsedInput && parsedInput !== 0) return;
 
-        if (input === 0) {
+        if (parsedInput === 0) {
           this.value = 0;
         } else {
-          this.value |= input;
+          this.value |= parsedInput;
         }
 
         this.selectedElement = null;

--- a/src/components/ConfigFields/InputFlag.vue
+++ b/src/components/ConfigFields/InputFlag.vue
@@ -1,22 +1,19 @@
 <template>
   <div class="form-item input-option">
-    <input-label :label="label" :has-description="hasDescription"></input-label>
+    <input-label :label="label" :hasDescription="hasDescription"></input-label>
 
     <div class="form-item__value">
-      <div class="input-option__field">
-        <select :id="field" v-model="flagValue" class="form-item__input">
-          <option v-for="(flagValue, name) in flags" v-show="flagValue === 0 || !((value & flagValue) === flagValue)" :key="name" :value="flagValue">
-            {{ name }}
-          </option>
-        </select>
-        <button class="button" @click.prevent="addFlag">
-          {{ $t('add') }}
-        </button>
-      </div>
+      <select :id="field" v-model="selectedElement" class="form-item__input" @change="addFlag($event.target.value)">
+        <!-- TODO - add that text to localization instead of hardcoding it -->
+        <option :value="null" disabled selected hidden>Select Option</option>
+        <option v-for="(enumValue, name) in flags" v-show="enumValue === 0 || !((value & enumValue) === enumValue)" :key="name" :value="enumValue">
+          {{ name }}
+        </option>
+      </select>
 
       <div class="input-option__items">
-        <button v-for="i in 32" v-if="value & (1 << i)" :key="i" class="button input-option__item" @click.prevent="removeFlag(1 << i)">
-          {{ resolveFlagName(1 << i) }}
+        <button v-for="enumValue in getSelectedFlagValues()" :key="enumValue" class="button input-option__item" @click.prevent="removeFlag(enumValue)">
+          {{ resolveFlagName(enumValue) }}
         </button>
       </div>
     </div>
@@ -33,7 +30,7 @@
     mixins: [Input],
     data() {
       return {
-        flagValue: this.schema.defaultValue,
+        selectedElement: null,
       };
     },
     computed: {
@@ -42,12 +39,23 @@
       },
     },
     methods: {
-      addFlag() {
-        if (!this.flagValue && this.flagValue !== 0) return;
+      getSelectedFlagValues() {
+        return [...Array(32).keys()].map(i => 1 << i).filter(val => this.value & val);
+      },
+      addFlag(input) {
+        if (typeof (input) !== typeof (0)) {
+          input = parseInt(input, 10);
+        }
 
-        if (this.flagValue === 0) this.value = 0;
-        this.value |= this.flagValue;
-        this.flagValue = this.schema.defaultValue;
+        if (!input && input !== 0) return;
+
+        if (input === 0) {
+          this.value = 0;
+        } else {
+          this.value |= input;
+        }
+
+        this.selectedElement = null;
       },
       removeFlag(value) {
         this.value &= ~value;

--- a/src/components/ConfigFields/InputList.vue
+++ b/src/components/ConfigFields/InputList.vue
@@ -5,7 +5,7 @@
     <div class="form-item__value">
       <select :id="field" v-model="selectedElement" class="form-item__input" :disabled="!availableEnumValues.length" @change="addElement($event.target.value)">
         <!-- TODO - add that text to localization instead of hardcoding it -->
-        <option :value="null" disabled selected hidden>Select Option</option>
+        <option :value="null" disabled selected hidden>{{ $t('input-select-enum-value') }}</option>
         <option v-for="(enumValue, name) in enumValues" v-show="!value.includes(enumValue)" :key="name" :value="enumValue">
           {{ name }}
         </option>

--- a/src/components/ConfigFields/InputList.vue
+++ b/src/components/ConfigFields/InputList.vue
@@ -4,7 +4,6 @@
 
     <div class="form-item__value">
       <select :id="field" v-model="selectedElement" class="form-item__input" :disabled="!availableEnumValues.length" @change="addElement($event.target.value)">
-        <!-- TODO - add that text to localization instead of hardcoding it -->
         <option :value="null" disabled selected hidden>{{ $t('input-select-enum-value') }}</option>
         <option v-for="(enumValue, name) in enumValues" v-show="!value.includes(enumValue)" :key="name" :value="enumValue">
           {{ name }}

--- a/src/components/ConfigFields/InputList.vue
+++ b/src/components/ConfigFields/InputList.vue
@@ -1,25 +1,21 @@
 <template>
   <div class="form-item">
-    <input-label :label="label" :has-description="hasDescription"></input-label>
+    <input-label :label="label" :hasDescription="hasDescription"></input-label>
 
     <div class="form-item__value">
-      <div class="input-option__field">
-        <select :id="field" v-model="element" class="form-item__input" :disabled="!availableEnumValues.length">
-          <option v-for="(enumValue, name) in enumValues" v-show="!value.includes(enumValue)" :key="name" :value="enumValue">
-            {{ name }}
-          </option>
-          <option v-if="!availableEnumValues.length" :value="undefined" disabled>
-            {{ $t('input-all-selected') }}
-          </option>
-        </select>
-
-        <button class="button" @click.prevent="addElement">
-          {{ $t('add') }}
-        </button>
-      </div>
+      <select :id="field" v-model="selectedElement" class="form-item__input" :disabled="!availableEnumValues.length" @change="addElement($event.target.value)">
+        <!-- TODO - add that text to localization instead of hardcoding it -->
+        <option :value="null" disabled selected hidden>Select Option</option>
+        <option v-for="(enumValue, name) in enumValues" v-show="!value.includes(enumValue)" :key="name" :value="enumValue">
+          {{ name }}
+        </option>
+        <option v-if="!availableEnumValues.length" :value="undefined" disabled>
+          {{ $t('input-all-selected') }}
+        </option>
+      </select>
 
       <div class="input-option__items">
-        <button v-for="(item, index) in value" :key="index" class="button input-option__item" @click.prevent="removeElement(index)">
+        <button v-for="(item, index) in value" :key="index" class="button input-option__item" @click.prevent="removeElementAtIndex(index)">
           {{ resolveOption(item) }}
         </button>
       </div>
@@ -37,7 +33,7 @@
     mixins: [Input],
     data() {
       return {
-        element: null,
+        selectedElement: null,
       };
     },
     computed: {
@@ -55,23 +51,22 @@
         return this.schema.values.values;
       },
     },
-    created() {
-      this.element = this.getDefaultElement();
-    },
     methods: {
       getDefaultElement() {
         return this.availableEnumValues[0];
       },
-      addElement() {
-        if (!this.element && this.element !== 0) return;
-        if (this.value.includes(this.element)) return;
+      addElement(input) {
+        if (typeof (input) !== (typeof (0))) {
+          input = parseInt(input, 10);
+        }
 
-        this.value.push(this.element);
-        this.element = this.getDefaultElement();
+        if (this.value.includes(input)) return;
+
+        this.value.push(input);
+        this.selectedElement = null;
       },
-      removeElement(index) {
+      removeElementAtIndex(index) {
         this.value.splice(index, 1);
-        this.element = this.getDefaultElement();
       },
       resolveOption(value) {
         return Object.keys(this.enumValues).find(key => this.enumValues[key] === value);

--- a/src/components/ConfigFields/InputList.vue
+++ b/src/components/ConfigFields/InputList.vue
@@ -52,13 +52,11 @@
     },
     methods: {
       addElement(input) {
-        if (typeof (input) !== (typeof (0))) {
-          input = parseInt(input, 10);
-        }
+        const parsedInput = typeof (input) !== (typeof (0)) ? parseInt(input, 10) : input;
 
-        if (this.value.includes(input)) return;
+        if (this.value.includes(parsedInput)) return;
 
-        this.value.push(input);
+        this.value.push(parsedInput);
         this.selectedElement = null;
       },
       removeElementAtIndex(index) {

--- a/src/components/ConfigFields/InputList.vue
+++ b/src/components/ConfigFields/InputList.vue
@@ -51,9 +51,6 @@
       },
     },
     methods: {
-      getDefaultElement() {
-        return this.availableEnumValues[0];
-      },
       addElement(input) {
         if (typeof (input) !== (typeof (0))) {
           input = parseInt(input, 10);

--- a/src/components/ConfigFields/InputSet.vue
+++ b/src/components/ConfigFields/InputSet.vue
@@ -5,7 +5,7 @@
     <div class="form-item__value">
       <select :id="field" v-model="selectedElement" class="form-item__input" :disabled="!availableEnumValues.length" @change="addElement($event.target.value)">
         <!-- TODO - add that text to localization instead of hardcoding it -->
-        <option :value="null" disabled selected hidden>Select Option</option>
+        <option :value="null" disabled selected hidden>{{ $t('input-select-enum-value') }}</option>
         <option v-for="(enumValue, name) in enumValues" v-show="!value.includes(enumValue)" :key="name" :value="enumValue">
           {{ name }}
         </option>

--- a/src/components/ConfigFields/InputSet.vue
+++ b/src/components/ConfigFields/InputSet.vue
@@ -1,25 +1,21 @@
 <template>
   <div class="form-item">
-    <input-label :label="label" :has-description="hasDescription"></input-label>
+    <input-label :label="label" :hasDescription="hasDescription"></input-label>
 
     <div class="form-item__value">
-      <div class="input-option__field">
-        <select :id="field" v-model="element" class="form-item__input" :disabled="!availableEnumValues.length">
-          <option v-for="(enumValue, name) in enumValues" v-show="!value.includes(enumValue)" :key="name" :value="enumValue">
-            {{ name }}
-          </option>
-          <option v-if="!availableEnumValues.length" :value="undefined" disabled>
-            {{ $t('input-all-selected') }}
-          </option>
-        </select>
-
-        <button class="button" @click.prevent="addElement">
-          {{ $t('add') }}
-        </button>
-      </div>
+      <select :id="field" v-model="selectedElement" class="form-item__input" :disabled="!availableEnumValues.length" @change="addElement($event.target.value)">
+        <!-- TODO - add that text to localization instead of hardcoding it -->
+        <option :value="null" disabled selected hidden>Select Option</option>
+        <option v-for="(enumValue, name) in enumValues" v-show="!value.includes(enumValue)" :key="name" :value="enumValue">
+          {{ name }}
+        </option>
+        <option v-if="!availableEnumValues.length" :value="undefined" disabled>
+          {{ $t('input-all-selected') }}
+        </option>
+      </select>
 
       <div class="input-option__items">
-        <button v-for="(item, index) in value" :key="index" class="button input-option__item" @click.prevent="removeElement(index)">
+        <button v-for="(item, index) in value" :key="index" class="button input-option__item" @click.prevent="removeElement(item)">
           {{ resolveOption(item) }}
         </button>
       </div>
@@ -37,7 +33,7 @@
     mixins: [Input],
     data() {
       return {
-        element: null,
+        selectedElement: null,
       };
     },
     computed: {
@@ -57,24 +53,29 @@
     },
     created() {
       this.value.sort();
-      this.element = this.getDefaultElement();
     },
     methods: {
       getDefaultElement() {
         return this.availableEnumValues[0];
       },
-      addElement() {
-        if (!this.element && this.element !== 0) return;
-        if (this.value.includes(this.element)) return;
+      addElement(input) {
+        if (typeof (input) !== (typeof (0))) {
+          input = parseInt(input, 10);
+        }
 
-        this.value.push(this.element);
+        if (this.value.includes(input)) return;
+
+        this.value.push(input);
         this.value.sort();
 
-        this.element = this.getDefaultElement();
+        this.selectedElement = null;
       },
-      removeElement(index) {
-        this.value.splice(index, 1);
-        this.element = this.getDefaultElement();
+      removeElement(input) {
+        if (typeof (input) !== (typeof (0))) {
+          input = parseInt(input);
+        }
+
+        this.value = this.value.filter(item => item !== input);
       },
       resolveOption(value) {
         return Object.keys(this.enumValues).find(key => this.enumValues[key] === value);

--- a/src/components/ConfigFields/InputSet.vue
+++ b/src/components/ConfigFields/InputSet.vue
@@ -4,7 +4,6 @@
 
     <div class="form-item__value">
       <select :id="field" v-model="selectedElement" class="form-item__input" :disabled="!availableEnumValues.length" @change="addElement($event.target.value)">
-        <!-- TODO - add that text to localization instead of hardcoding it -->
         <option :value="null" disabled selected hidden>{{ $t('input-select-enum-value') }}</option>
         <option v-for="(enumValue, name) in enumValues" v-show="!value.includes(enumValue)" :key="name" :value="enumValue">
           {{ name }}

--- a/src/components/ConfigFields/InputSet.vue
+++ b/src/components/ConfigFields/InputSet.vue
@@ -55,13 +55,11 @@
     },
     methods: {
       addElement(input) {
-        if (typeof (input) !== (typeof (0))) {
-          input = parseInt(input, 10);
-        }
+        const parsedInput = typeof (input) !== (typeof (0)) ? parseInt(input, 10) : input;
 
-        if (this.value.includes(input)) return;
+        if (this.value.includes(parsedInput)) return;
 
-        this.value.push(input);
+        this.value.push(parsedInput);
         this.value.sort();
 
         this.selectedElement = null;

--- a/src/components/ConfigFields/InputSet.vue
+++ b/src/components/ConfigFields/InputSet.vue
@@ -54,9 +54,6 @@
       this.value.sort();
     },
     methods: {
-      getDefaultElement() {
-        return this.availableEnumValues[0];
-      },
       addElement(input) {
         if (typeof (input) !== (typeof (0))) {
           input = parseInt(input, 10);

--- a/src/i18n/locale/default.json
+++ b/src/i18n/locale/default.json
@@ -95,7 +95,7 @@
   "input-label-steamguard": "Steam Guard code",
   "input-label-steamparentalcode": "Steam Parental code",
   "input-label-twofactorauthentication": "2FA code",
-  "input-select-enum-value": "Select Option",
+  "input-select-enum-value": "Select option",
   "input-no-code-login": "You have to enter a Steam login name",
   "input-no-code-password": "You have to enter a Steam password",
   "input-no-code-steamguard": "You have to enter a Steam Guard code",

--- a/src/i18n/locale/default.json
+++ b/src/i18n/locale/default.json
@@ -95,6 +95,7 @@
   "input-label-steamguard": "Steam Guard code",
   "input-label-steamparentalcode": "Steam Parental code",
   "input-label-twofactorauthentication": "2FA code",
+  "input-select-enum-value": "Select Option",
   "input-no-code-login": "You have to enter a Steam login name",
   "input-no-code-password": "You have to enter a Steam password",
   "input-no-code-steamguard": "You have to enter a Steam Guard code",


### PR DESCRIPTION
## Description
Implements #1449 for `InputFlag`, `InputSet` and `InputList`.

## Screenshots
![image](https://user-images.githubusercontent.com/6608231/123276347-602c4980-d505-11eb-9258-9f29882b4015.png)

## Additional remarks
I'd propose renaming the three above mentioned components to contain the n word "Enum", since they are exclusively used for that and the name implies a more generic usage (e.g. them also being used for config fields such as `GamesPlayedWhileIdle`, which is also `ImmutableHashSet<...>` under the hood), but I have no idea of how to do this.

## Checklist
<!--- Please go through this checklist before you submit your pull request. -->
- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [x] I added a concise description or a self-explanatory screenshot to this pull request
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
