### PR TITLE
Add "show password" button to setup page

### DIFF
--- a/src/style/_form.scss
+++ b/src/style/_form.scss
@@ -65,6 +65,18 @@
 	}
 }
 
+.form-item__code {
+  display: grid;
+  grid-column-gap: 0.5em;
+  grid-template-columns: 1fr auto;
+  align-items: flex-end;
+  padding-bottom: 1em;
+
+  :focus {
+    outline: none;
+  }
+}
+
 .form-item__input {
 	background-color: var(--color-background);
 	border: 1px solid rgba($color-text-dark, 0.1);

--- a/src/views/Setup.vue
+++ b/src/views/Setup.vue
@@ -12,8 +12,18 @@
       <p v-if="statusText" class="status-text" v-html="statusText"></p>
 
       <div v-if="status === 'UNAUTHORIZED'" class="form-item">
-        <label for="password" class="form-item__label">{{ $t('password') }}</label>
-        <input id="password" v-model="password" class="form-item__input" type="password" @keydown.enter="updatePassword">
+        <div class="form-item__code">
+          <div>
+            <label for="password" class="form-item__label">{{ $t('password') }}</label>
+            <input id="password" v-model="password" class="form-item__input" type="password" @keydown.enter="updatePassword">
+          </div>
+          <div class="form-item__buttons form-item__buttons--column">
+            <button v-tooltip="$t('input-switch-visibility')" class="button button--helper" @click="switchInputType">
+              <FontAwesomeIcon v-if="inputHidden" icon="eye" size="lg"></FontAwesomeIcon>
+              <FontAwesomeIcon v-else icon="eye-slash" size="lg"></FontAwesomeIcon>
+            </button>
+          </div>
+        </div>
       </div>
 
       <div v-if="status !== 'AUTHENTICATED'" class="form-item">
@@ -47,6 +57,7 @@
         processing: false,
         countdown: 5,
         timer: null,
+        inputHidden: true,
       };
     },
     computed: {
@@ -104,6 +115,13 @@
       this.cancelAutoUpdate();
     },
     methods: {
+      switchInputType() {
+        this.inputHidden = !this.inputHidden;
+        const field = document.getElementById('password');
+
+        if (field.getAttribute('type') === 'password') field.setAttribute('type', 'text');
+        else field.setAttribute('type', 'password');
+      },
       async handleWaiting(mode = 'restart') {
         this.processing = true;
         await waitForRestart();
@@ -192,11 +210,15 @@
 </script>
 
 <style lang="scss">
-	.status-text {
-		text-align: center;
+  .status-text {
+    text-align: center;
 
     a {
       color: var(--color-theme);
     }
-	}
+  }
+
+  .button--helper {
+    max-width: 2em;
+  }
 </style>

--- a/src/views/modals/BotInput.vue
+++ b/src/views/modals/BotInput.vue
@@ -104,18 +104,6 @@
     padding-bottom: 1em;
   }
 
-  .form-item__code {
-    display: grid;
-    grid-column-gap: 0.5em;
-    grid-template-columns: 1fr auto;
-    align-items: flex-end;
-    padding-bottom: 1em;
-
-    :focus {
-      outline: none;
-    }
-  }
-
   .button--helper {
     max-width: 2em;
   }


### PR DESCRIPTION
## Description

This merge request adds a "show password" button to the setup page. This is a recommendation for safe passwords per NIST:

> In order to assist the claimant in successfully entering a memorized secret, the verifier SHOULD offer an option to display the secret — rather than a series of dots or asterisks — until it is entered. This allows the claimant to verify their entry if they are in a location where their screen is unlikely to be observed.

Giving the user an option to check whether they made a typo increases their chance of choosing a longer, safer password in the first place.

Since we already had similar logic for the modal that opens when a bot instance requires input, it was a pretty straight-forward implementation. 😁

## Screenshots

![image](https://user-images.githubusercontent.com/6608231/135689932-da0dbbba-040d-4865-9440-3b0edad73567.png)
![image](https://user-images.githubusercontent.com/6608231/135689947-85a01c63-2b96-497d-a25b-6acc44768b6b.png)


## Checklist
- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [x] I added a concise description or a self-explanatory screenshot to this pull request
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
