### PR TITLE
Replace deprecated 'linkifyjs/html' with 'linkify-html'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5485,6 +5485,11 @@
         "type-check": "~0.4.0"
       }
     },
+    "linkify-html": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-html/-/linkify-html-3.0.2.tgz",
+      "integrity": "sha512-vHIFhMjEFptdaRqk6wfNmtoBKkFPAkZGUwsThMafSnkqc02gZc6+bfAAxVgMZAn7NTxDYgSW2q04kmVAzYtEaA=="
+    },
     "linkifyjs": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-3.0.2.tgz",
@@ -5793,9 +5798,9 @@
       }
     },
     "nth-check": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
-      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+      "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
       "requires": {
         "boolbase": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "flat": "5.0.2",
     "html-webpack-plugin": "5.3.2",
     "humanize-duration": "3.27.0",
+    "linkify-html": "^3.0.2",
     "linkifyjs": "3.0.2",
     "lodash-es": "4.17.21",
     "plurals-cldr": "1.0.4",

--- a/src/components/ASF/Releases.vue
+++ b/src/components/ASF/Releases.vue
@@ -26,7 +26,7 @@
 <script>
   import { mapGetters } from 'vuex';
   import humanizeDuration from 'humanize-duration';
-  import linkifyHtml from 'linkifyjs/html';
+  import linkifyHtml from 'linkify-html';
   import getLocaleForHD from '../../utils/getLocaleForHD';
   import * as storage from '../../utils/storage';
   import compareVersion from '../../utils/compareVersion';


### PR DESCRIPTION
"linkifyjs/html" is deprecated in linkifyjs v3. We now use "linkify-html" instead.