### PR TITLE
fix with DPI Scaling

### DIFF
--- a/src/components/utils/FitText.vue
+++ b/src/components/utils/FitText.vue
@@ -19,7 +19,7 @@
         type: String,
       },
       min: {
-        default: 0.5,
+        default: 1,
         type: Number,
       },
       max: {


### PR DESCRIPTION
With DPI scaling the number of bots is displayed incorrectly in Google Chrome
Before:
![2](https://user-images.githubusercontent.com/17289889/149774500-5233d0dc-6aa5-494d-aede-e629d30f113d.png)
After:
![1](https://user-images.githubusercontent.com/17289889/149774554-68d46a04-4302-4c0d-9b7e-61e36de1c230.png)

