### PR TITLE
fix: props type error

### DIFF
--- a/src/components/Navigation/Statistic.vue
+++ b/src/components/Navigation/Statistic.vue
@@ -18,7 +18,7 @@
       },
       value: {
         required: true,
-        type: String,
+        type: [String, Number],
       },
       icon: {
         required: true,


### PR DESCRIPTION
## Description
I notice the console keep print `vue warn` in develop mode. Because in `Statistic.vue`, the props named `value` expected a `String`, but got a `Number`. Now it can get `Number` or `String`.

## Screenshots
<!-- If applicable, add screenshots to visualize your changes. -->
![image-20220624094445935.png](https://s2.loli.net/2022/06/24/gRMaxQEerW3BUy4.png)
## Additional information
<!-- Add any other information about your pull request here. -->

## Checklist
<!--- Please go through this checklist before you submit your pull request. -->
- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [x] I added a concise description or a self-explanatory screenshot to this pull request
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
