### PR TITLE
Link to ASF discussions instead of issues for questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/Question.yml
+++ b/.github/ISSUE_TEMPLATE/Question.yml
@@ -12,7 +12,7 @@ body:
           required: true
         - label: I also read **[FAQ](https://github.com/JustArchiNET/ASF-ui/wiki/FAQ)**
           required: true
-        - label: This is not **[ASF question](https://github.com/JustArchiNET/ArchiSteamFarm/issues/new/choose)**
+        - label: This is not **[ASF question](https://github.com/JustArchiNET/ArchiSteamFarm/discussions/new?category=Support)**
           required: true
   - type: textarea
     id: question


### PR DESCRIPTION
## Description

ASF core doesn't want support questions to be issues. They should be discussions instead. Reflect this in the link of the issue template for questions in this repository.

## Additional information

Thank you for considering the inclusion of this merge request.

## Checklist

- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [x] I added a concise description or a self-explanatory screenshot to this pull request
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
