### PR TITLE
Fix endpoint path to be relative

### DIFF
--- a/src/utils/swagger/parse.js
+++ b/src/utils/swagger/parse.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { dereference } from './dereference';
 
-const endpoint = 'http://localhost:8080/swagger/ASF/swagger.json';
+const endpoint = '/swagger/ASF/swagger.json';
 let schema;
 
 async function getSchema() {


### PR DESCRIPTION
## Description
By some mistake ASF-ui uses localhost:8080 as base url for one of requests. Not only it uses outright wrong port, but also will not work when accessing ASF-ui not from localhost. I changed it to be relative path instead. As a consequence of this bug steam wallet funds were not shown in ASF-ui (https://steamcommunity.com/groups/archiasf/discussions/1/3459347019172139874/ for reference)

## Screenshots
Without this fix:
![image](https://user-images.githubusercontent.com/15903022/184012865-606682b8-12ae-4a29-900e-887dfe52a327.png)

With this fix:
![image](https://user-images.githubusercontent.com/15903022/184012743-1b73405f-51f7-407f-9ae8-99b236df6674.png)


## Additional information
I checked and it works for me.

## Checklist
<!--- Please go through this checklist before you submit your pull request. -->
- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [x] I added a concise description or a self-explanatory screenshot to this pull request
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
