### PR TITLE
Fix fetching swagger data when using base path

### DIFF
--- a/src/utils/swagger/parse.js
+++ b/src/utils/swagger/parse.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { dereference } from './dereference';
 
-const endpoint = `${window.__BASE_PATH__ ?? "/"}swagger/ASF/swagger.json`;
+const endpoint = `${window.__BASE_PATH__ ?? '/'}swagger/ASF/swagger.json`;
 let schema;
 
 async function getSchema() {

--- a/src/utils/swagger/parse.js
+++ b/src/utils/swagger/parse.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { dereference } from './dereference';
 
-const endpoint = '/swagger/ASF/swagger.json';
+const endpoint = `${window.__BASE_PATH__ ?? "/"}swagger/ASF/swagger.json`;
 let schema;
 
 async function getSchema() {


### PR DESCRIPTION
## Description
Use base path when fetching swagger data, fixes not showing bot’s balance with base path.

## Screenshots
None

## Additional information
Closes https://github.com/JustArchiNET/ASF-ui/issues/1663

## Checklist
- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [x] I added a concise description or a self-explanatory screenshot to this pull request
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
