### PR TITLE
Allow treating config fields as sensitive

### DIFF
--- a/src/components/Config/Fields/Input.vue
+++ b/src/components/Config/Fields/Input.vue
@@ -54,6 +54,9 @@
       errorText() {
         return this.errors.map(error => `Value is ${error}!`).join(' ');
       },
+      sensitive() {
+        return !!this.schema.sensitive;
+      },
     },
     watch: {
       value: {

--- a/src/components/Config/Fields/InputString.vue
+++ b/src/components/Config/Fields/InputString.vue
@@ -3,7 +3,7 @@
     <input-label :label="label" :hasDescription="hasDescription"></input-label>
 
     <div class="form-item__value">
-      <input :id="field" v-model="value" class="form-item__input" type="text" :name="field" :placeholder="placeholder" @blur="onBlur" @keypress="onKeyPress">
+      <input :id="field" v-model="value" class="form-item__input" :type="fieldType" :name="field" :placeholder="placeholder" @focus="onFocus" @blur="onBlur" @keypress="onKeyPress">
       <span v-if="hasErrors" class="form-item__error">{{ errorText }}</span>
     </div>
 
@@ -17,11 +17,31 @@
   export default {
     name: 'InputString',
     mixins: [Input],
+    data() {
+      return {
+        active: false,
+      };
+    },
+    computed: {
+      fieldType() {
+        if (this.sensitive && !this.active) {
+          return 'password';
+        }
+
+        return 'text';
+      },
+    },
     methods: {
+      onFocus() {
+        this.active = true;
+      },
       onBlur() {
+        this.active = false;
         if (this.value === '') this.value = this.defaultValue;
       },
       onKeyPress($event) {
+        this.active = true;
+
         if (this.schema.type !== 'uint64') return true;
 
         const charCode = ($event.which) ? $event.which : $event.keyCode;

--- a/src/views/ASFConfig.vue
+++ b/src/views/ASFConfig.vue
@@ -106,6 +106,7 @@
 
           const extendedFields = {
             IPCPassword: { placeholder: this.$t('keep-unchanged') },
+            LicenseID: { sensitive: true },
           };
 
           this.fields = Object.keys(fields).map(key => {


### PR DESCRIPTION
## Description

Add `sensitive` prop to field schema definition. Setting this prop to `true` should make inputs of type `String` mask the value to prevent leaking (eg. via screenshots or screenshare). The value is unmasked when user focuses the input to allow for easy editing / copying.

Resolves #1674, hopefully

## Screenshots
N/A, didn't test

## Additional information
Did not test the change, please test it before merging. Especially the masking / unmasking part. I believe browsers emit `focus` and `blur` in all scenarios.

## Checklist
<!--- Please go through this checklist before you submit your pull request. -->
- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [ ] I added a concise description or a self-explanatory screenshot to this pull request
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
