### PR TITLE
Fix ASF-ui wrong password format

### DIFF
--- a/src/views/ASFConfig.vue
+++ b/src/views/ASFConfig.vue
@@ -100,8 +100,13 @@
           // if we got routed to asf-config with params, we propably
           // came from PasswordHash.vue and want to set ipc data from params
           if (Object.keys(this.$route.params).length !== 0) {
-            this.model.IPCPassword = this.$route.params?.ipcPassword;
-            this.model.IPCPasswordFormat = this.$route.params?.ipcPasswordFormat;
+            // only set the values if they exist in the params
+            if (typeof this.$route.params?.ipcPassword !== 'undefined') {
+              this.model.IPCPassword = this.$route.params?.ipcPassword;
+            }
+            if (typeof this.$route.params?.ipcPasswordFormat !== 'undefined') {
+              this.model.IPCPasswordFormat = this.$route.params?.ipcPasswordFormat;
+            }
           }
 
           const extendedFields = {

--- a/src/views/ASFConfig.vue
+++ b/src/views/ASFConfig.vue
@@ -101,11 +101,11 @@
           // came from PasswordHash.vue and want to set ipc data from params
           if (Object.keys(this.$route.params).length !== 0) {
             // only set the values if they exist in the params
-            if (typeof this.$route.params?.ipcPassword !== 'undefined') {
-              this.model.IPCPassword = this.$route.params?.ipcPassword;
+            if (typeof this.$route.params.ipcPassword !== 'undefined') {
+              this.model.IPCPassword = this.$route.params.ipcPassword;
             }
-            if (typeof this.$route.params?.ipcPasswordFormat !== 'undefined') {
-              this.model.IPCPasswordFormat = this.$route.params?.ipcPasswordFormat;
+            if (typeof this.$route.params.ipcPasswordFormat !== 'undefined') {
+              this.model.IPCPasswordFormat = this.$route.params.ipcPasswordFormat;
             }
           }
 

--- a/src/views/modals/BotConfig.vue
+++ b/src/views/modals/BotConfig.vue
@@ -102,8 +102,13 @@
           // if we got routed to bot-config with params, we propably
           // came from PasswordEncrypt.vue and want to set password data from params
           if (Object.keys(this.$route.params).length !== 0) {
-            this.model.SteamPassword = this.$route.params?.steamPassword;
-            this.model.PasswordFormat = this.$route.params?.passwordFormat;
+            // only set the values if they exist in the params
+            if (typeof this.$route.params.steamPassword !== 'undefined') {
+              this.model.SteamPassword = this.$route.params.steamPassword;
+            }
+            if (typeof this.$route.params.passwordFormat !== 'undefined') {
+              this.model.PasswordFormat = this.$route.params.passwordFormat;
+            }
           }
 
           const extendedFields = {


### PR DESCRIPTION
## Description
<!--- A clear and concise description of your changes. -->
<!--- If it fixes or closes an open issue, please link to the issue here. -->
Fixes this issue - https://github.com/JustArchiNET/ASF-ui/issues/1651

## Screenshots
<!-- If applicable, add screenshots to visualize your changes. -->

<details>
  <summary>Changing <code>passwordFormat</code> to <code>AES</code></summary>
  <img src="https://github.com/user-attachments/assets/ba9e2581-c050-4b66-a213-84ab13267406" alt="Default passwordFormat">
    <img src="https://github.com/user-attachments/assets/2e25763a-3faa-44d7-9fe3-9f0708f35475" alt="Change to AES">
</details>

<details>
  <summary>New value for <code>passwordFormat</code></summary>
  <img src="https://github.com/user-attachments/assets/718af17f-8f74-47f9-bb65-a9ac94c8b6f4" alt="Updated passwordFormat">
</details>


## Additional information
<!-- Add any other information about your pull request here. -->
The issue is that if user didn't come from `PasswordEncrypt.vue`, then values in `this.$route.params` are `undefined` and thus they overwrite existing `passwordFormat` value

## Checklist
<!--- Please go through this checklist before you submit your pull request. -->
- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [x] I added a concise description or a self-explanatory screenshot to this pull request
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
