### PR TITLE
Fix an infinite redirect loop when settings:default-view is set to home

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -27,7 +27,7 @@ export default [
       if (botsDetected) {
         storage.set('setup-complete', true);
         let defaultView = store.getters['settings/defaultView'];
-        if (defaultView === '_last-visited-page') defaultView = storage.get('last-visited-page', { name: 'bots' });
+        if (defaultView === '_last-visited-page' || defaultView === 'home') defaultView = storage.get('last-visited-page', { name: 'bots' });
         const page = (typeof defaultView === 'string') ? { name: defaultView } : defaultView;
         return next(page);
       }


### PR DESCRIPTION
## Description
<!--- A clear and concise description of your changes. -->
<!--- If it fixes or closes an open issue, please link to the issue here. -->

Fixes this issue https://github.com/JustArchiNET/ASF-ui/issues/1496

## Screenshots
<!-- If applicable, add screenshots to visualize your changes. -->
<details>
  <summary>Network activity< (<code>/</code> path)</summary>
  <img src="https://github.com/user-attachments/assets/20cc1bd2-c54b-4264-bc09-5759cb164fa3" alt="Network activity">
</details>

## Additional information
Instead of redirecting to the `home` page and causing a loop, it redirects the user to the `bots` page

## Checklist
<!--- Please go through this checklist before you submit your pull request. -->
- [x] My pull request is not a duplicate
- [x] I added a descriptive title to this pull request
- [x] I added a concise description or a self-explanatory screenshot to this pull request
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
